### PR TITLE
Remove abs method from Flipper class

### DIFF
--- a/src/main/java/com/example/Flipper.java
+++ b/src/main/java/com/example/Flipper.java
@@ -28,14 +28,4 @@ public class Flipper {
         }
         return result;
     }
-    
-    /**
-     * 숫자의 절댕값을 반환합니다.
-     * 
-     * @param number 절댕값을 구할 숫자
-     * @return 숫자의 절댕값
-     */
-    public double abs(double number) {
-        return Math.abs(number);
-    }
 }


### PR DESCRIPTION
이 PR은 Flipper 클래스에서 불필요한 abs 메서드를 제거합니다.

## 변경사항
- `Flipper.java`에서 `abs` 메서드와 관련 주석 제거
- 코드 단순화 및 클래스의 단일 책임 원칙 강화

## 이유
- abs 메서드는 실제로 Calculator나 테스트에서 사용되지 않음
- Flipper 클래스는 부호 변경에만 집중하는 것이 더 명확함
- 한국어 오타("절댕값") 문제도 함께 해결됨

## 테스트
- 모든 기존 테스트는 여전히 정상 작동
- abs 메서드를 사용하는 테스트나 코드가 없어서 문제없음